### PR TITLE
Default to pulling the libusual submodule over https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib"]
 	path = lib
-	url = git@github.com:greenplum-db/libusual.git
+	url = https://github.com/greenplum-db/libusual.git


### PR DESCRIPTION
For people without ssh configured, this is best. If you do typically use
ssh to clone repositories, we recommend `pushInsteadOf`:
http://engineering.pivotal.io/post/git-push-instead-of/

Signed-off-by: Melanie Plageman <mplageman@pivotal.io>

Similar to https://github.com/greenplum-db/gpdb/pull/1950 ( @tushar-dadlani ) -- this comes up when recursively init'ing submodules