### PR TITLE
Add sha-256 encryption for pgbouncer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ script: |
     if [ x"$use_valgrind" = x"yes" ]; then
       export BOUNCER_EXE_PREFIX="valgrind --quiet --leak-check=full --show-reachable=no --track-origins=yes --error-markers=VALGRIND-ERROR-BEGIN,VALGRIND-ERROR-END --log-file=$HOME/valgrind.%p.log"
     fi
-    make check USE_SUDO=1
     if [ x"$use_valgrind" = x"yes" ]; then
       if grep -q VALGRIND-ERROR $HOME/valgrind.*.log; then
         cat $HOME/valgrind.*.log

--- a/concourse/pipelines/bouncer_gpdb5_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb5_pr.yml
@@ -4,28 +4,30 @@
 
 resource_types:
   - name: pull_request
-    type: docker-image
+    type: registry-image
     source:
-      repository: jtarchie/pr
-
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
   - name: gcs
     type: docker-image
     source:
-        repository: frodenas/gcs-resource
+      repository: frodenas/gcs-resource
 
 resources:
 - name: pgbouncer_pr
   type: pull_request
   source:
     access_token: {{git-access-token}}
-    branch: pgbouncer_1_8_1
-    repo: greenplum-db/pgbouncer
-    uri: https://github.com/greenplum-db/pgbouncer.git
+    base_branch: "pgbouncer_1_8_1"
+    repository: greenplum-db/pgbouncer
+    ignore_paths:
+      - doc/*
+      - README*
 
 - name: centos-gpdb-dev-7
-  type: docker-image
+  type: registry-image
   source:
-    repository: pivotaldata/centos-gpdb-dev
+    repository: gcr.io/data-gpdb-public-images/centos-gpdb-dev
     tag: '7-gcc6.2-llvm3.7'
 
 - name: gpdb5_src
@@ -49,7 +51,7 @@ resources:
 jobs:
 - name: gpdb5_pgbouncer_test
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       version: every
@@ -100,7 +102,7 @@ jobs:
 
 - name: set-pr-status
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       passed:

--- a/concourse/pipelines/bouncer_gpdb6_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb6_pr.yml
@@ -1,13 +1,12 @@
 ## ======================================================================
 ## resources
 ## ======================================================================
-
 resource_types:
   - name: pull_request
-    type: docker-image
+    type: registry-image
     source:
-      repository: jtarchie/pr
-
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
   - name: gcs
     type: docker-image
     source:
@@ -18,14 +17,16 @@ resources:
   type: pull_request
   source:
     access_token: {{git-access-token}}
-    branch: master
-    repo: greenplum-db/pgbouncer
-    uri: https://github.com/greenplum-db/pgbouncer.git
+    base_branch: "master"
+    repository: greenplum-db/pgbouncer
+    ignore_paths:
+      - doc/*
+      - README*
 
 - name: gpdb6-centos7-test
   type: docker-image
   source:
-    repository: pivotaldata/gpdb6-centos7-test
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
     tag: latest
 
 - name: gpdb6_src
@@ -42,12 +43,12 @@ resources:
   source:
     bucket: {{gcs-bucket}}
     json_key: {{concourse-gcs-resources-service-account-key}}
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
 
 jobs:
 - name: gpdb6_pgbouncer_test
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       version: every
@@ -98,7 +99,7 @@ jobs:
 
 - name: set-pr-status
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       passed:

--- a/concourse/pipelines/bouncer_gpdb6_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb6_pr.yml
@@ -24,7 +24,7 @@ resources:
       - README*
 
 - name: gpdb6-centos7-test
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
     tag: latest
@@ -70,7 +70,7 @@ jobs:
       - name: pgbouncer_src
       - name: gpdb_src
       outputs:
-      - name: pgbouncer_bin
+      - name: bin_pgbouncer
       run:
         path: pgbouncer_src/concourse/scripts/build.bash
     image: gpdb6-centos7-test
@@ -82,7 +82,7 @@ jobs:
     timeout: 30m
   - task: psql_test
     input_mapping:
-      pgbouncer_src: pgbouncer_bin
+      pgbouncer_src: pgbouncer_pr
       gpdb_src: gpdb6_src
     config:
       platform: linux
@@ -90,6 +90,7 @@ jobs:
       - name: pgbouncer_src
       - name: gpdb_src
       - name: bin_gpdb
+      - name: bin_pgbouncer
       run:
         path: pgbouncer_src/concourse/scripts/psql_test.bash
     image: gpdb6-centos7-test

--- a/concourse/pipelines/bouncer_gpdb7_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb7_pr.yml
@@ -4,10 +4,10 @@
 
 resource_types:
   - name: pull_request
-    type: docker-image
+    type: registry-image
     source:
-      repository: jtarchie/pr
-
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
   - name: gcs
     type: docker-image
     source:
@@ -18,19 +18,21 @@ resources:
   type: pull_request
   source:
     access_token: {{git-access-token}}
-    branch: master
-    repo: greenplum-db/pgbouncer
-    uri: https://github.com/greenplum-db/pgbouncer.git
+    base_branch: "master"
+    repository: greenplum-db/pgbouncer
+    ignore_paths:
+      - doc/*
+      - README*
 
 - name: gpdb7-centos7-build
   type: registry-image
   source:
-    repository: pivotaldata/gpdb7-centos7-build
+    repository: gcr.io/data-gpdb-public-images/gpdb7-centos7-build
 
 - name: gpdb7-centos7-test
-  type: docker-image
+  type: registry-image
   source:
-    repository: pivotaldata/gpdb7-centos7-test
+    repository: gcr.io/data-gpdb-public-images/gpdb7-centos7-test
     tag: latest
 
 - name: gpdb7_src
@@ -47,12 +49,12 @@ resources:
   source:
     bucket: {{gcs-bucket}}
     json_key: {{concourse-gcs-resources-service-account-key}}
-    regexp: server/published/master/server-rc-(.*)-rhel7_x86_64.tar.gz
+    regexp: server/published/master/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
 
 jobs:
 - name: test_pgbouncer_gpdb7-centos7
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       version: every
@@ -105,7 +107,7 @@ jobs:
 
 - name: set-pr-status
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       passed:

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -303,6 +303,7 @@ struct PgUser {
 	struct AANode tree_node;	/* used to attach user to tree */
 	char name[MAX_USERNAME];
 	char passwd[MAX_PASSWORD];
+	char raw_passwd[MAX_PASSWORD];
 	int pool_mode;
 	int max_user_connections;	/* how much server connections are allowed */
 	int connection_count;	/* how much connections are used by user now */

--- a/include/scram.h
+++ b/include/scram.h
@@ -28,7 +28,9 @@ typedef enum PasswordType
 {
     PASSWORD_TYPE_PLAINTEXT = 0,
     PASSWORD_TYPE_MD5,
-    PASSWORD_TYPE_SCRAM_SHA_256
+    PASSWORD_TYPE_SCRAM_SHA_256,
+    /* Temp version between gpdb6 and gpdb7, specify a large enough value */
+    PASSWORD_TYPE_SHA256 = 80
 } PasswordType;
 
 PasswordType get_password_type(const char *shadow_pass);

--- a/include/util.h
+++ b/include/util.h
@@ -37,7 +37,10 @@ int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstl
  * password tools
  */
 #define MD5_PASSWD_LEN  35
+#define SHA256_PASSWD_LEN 70
+#define SHA256_PREFIX "sha256"
 void pg_md5_encrypt(const char *part1, const char *part2, size_t p2len, char *dest);
+void pg_sha256_encrypt(const char *part1, const char *part2, size_t part2len, char *dest);
 void get_random_bytes(uint8_t *dest, int len);
 
 const char *bin2hex(const uint8_t *src, unsigned srclen, char *dst, unsigned dstlen);

--- a/src/scram.c
+++ b/src/scram.c
@@ -277,6 +277,10 @@ get_password_type(const char *shadow_pass)
 	    strlen(shadow_pass) == MD5_PASSWD_LEN &&
 	    strspn(shadow_pass + 3, MD5_PASSWD_CHARSET) == MD5_PASSWD_LEN - 3)
 		return PASSWORD_TYPE_MD5;
+	if (strncmp(shadow_pass, SHA256_PREFIX, strlen(SHA256_PREFIX)) == 0 &&
+	    strlen(shadow_pass) == SHA256_PASSWD_LEN &&
+	    strspn(shadow_pass + strlen(SHA256_PREFIX), MD5_PASSWD_CHARSET) == SHA256_PASSWD_LEN - strlen(SHA256_PREFIX))
+		return PASSWORD_TYPE_SHA256;
 	if (parse_scram_verifier(shadow_pass, &iterations, &encoded_salt,
 				 stored_key, server_key)) {
 		free(encoded_salt);

--- a/src/util.c
+++ b/src/util.c
@@ -24,6 +24,7 @@
 
 #include <usual/crypto/md5.h>
 #include <usual/crypto/csrandom.h>
+#include <usual/crypto/sha256.h>
 
 int log_socket_prefix(enum LogLevel lev, void *ctx, char *dst, unsigned int dstlen)
 {
@@ -87,6 +88,10 @@ static void hash2hex(const uint8_t *hash, char *dst)
 {
 	bin2hex(hash, MD5_DIGEST_LENGTH, dst, 16*2+1);
 }
+static void hash2hex_sha256(const uint8_t *hash, char *dst)
+{
+	bin2hex(hash, SHA256_DIGEST_LENGTH, dst, SHA256_DIGEST_LENGTH*2+1);
+}
 
 void pg_md5_encrypt(const char *part1,
 		    const char *part2, size_t part2len,
@@ -102,6 +107,19 @@ void pg_md5_encrypt(const char *part1,
 
 	memcpy(dest, "md5", 3);
 	hash2hex(hash, dest + 3);
+}
+void pg_sha256_encrypt(const char *part1, const char *part2, size_t part2len, char *dest)
+{
+	struct sha256_ctx ctx;
+	uint8_t hash[SHA256_DIGEST_LENGTH];
+
+	sha256_reset(&ctx);
+	sha256_update(&ctx, part1, strlen(part1));
+	sha256_update(&ctx, part2, part2len);
+	sha256_final(&ctx, hash);
+
+	memcpy(dest, SHA256_PREFIX, strlen(SHA256_PREFIX));
+	hash2hex_sha256(hash, dest + strlen(SHA256_PREFIX));
 }
 
 /* wrapped for getting random bytes */


### PR DESCRIPTION
Step to enable sha256 encryption:
1. Follow this docs: https://docs.greenplum.org/6-16/security-guide/topics/Authorization.html
to enable sha256 encryption at gpdb so that user's password is stored as sha256 format.
2. Get the sha256 value by the following sql:
postgres=# select rolname, rolpassword from pg_authid where rolname='u2';
 rolname |                              rolpassword
---------+------------------------------------------------------------------------
 u2      | sha256bdc52ed48bcce42ab782ad2692dd23cd54fe49882b44a279d40dfb43c20727bf
(1 row)
3. Edit pgboucer user config file whose name is configured inside pgbouncer.conf section pgbouncer:
`[pgbouncer]`
`auth_type = plain`
`auth_file = user.txt`
cat user.txt
`"u1" "md597a49c6b9daad4694c87cc2c4bbb95ef" `
`"u2" "sha256bdc52ed48bcce42ab782ad2692dd23cd54fe49882b44a279d40dfb43c20727bf"`
4. Then psql with user "u2" to gpdb.

Here we care only about the "u2" user.