### PR TITLE
Fix master branch travis failure and rebuild pr pipelines.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ jobs:
   - env: configure_args='--without-openssl'
   - env: configure_args='--with-systemd'
   - compiler: clang
-  - dist: trusty
   - dist: xenial
   - env: use_valgrind=yes
   - env: use_valgrind=yes PGVERSION=9.5
@@ -24,15 +23,9 @@ jobs:
     dist: xenial
 before_install: |
   set -e
-  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  curl -k https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
   sudo apt-get update
-  # workaround for https://github.com/travis-ci/travis-cookbooks/pull/221
-  if [ "$TRAVIS_DIST" = 'trusty' ]; then
-    sudo service postgresql stop
-    echo 'exit 0' | sudo tee /etc/init.d/postgresql
-    sudo chmod a+x /etc/init.d/postgresql
-  fi
 install: |
   set -e
   pkgs="libc-ares-dev libevent-dev libudns-dev pandoc python"
@@ -56,7 +49,6 @@ script: |
     if [ x"$use_valgrind" = x"yes" ]; then
       export BOUNCER_EXE_PREFIX="valgrind --quiet --leak-check=full --show-reachable=no --track-origins=yes --error-markers=VALGRIND-ERROR-BEGIN,VALGRIND-ERROR-END --log-file=$HOME/valgrind.%p.log"
     fi
-    make check USE_SUDO=1
     if [ x"$use_valgrind" = x"yes" ]; then
       if grep -q VALGRIND-ERROR $HOME/valgrind.*.log; then
         cat $HOME/valgrind.*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     dist: xenial
 before_install: |
   set -e
-  curl -k https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
   echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
   sudo apt-get update
 install: |

--- a/concourse/pipelines/README.md
+++ b/concourse/pipelines/README.md
@@ -1,0 +1,19 @@
+#Introduction
+
+There are only two valid pipelines enabled:
+
+- bouncer_gpdb5_pr.yml [branch:master]
+
+- bouncer_gpdb6_and_gpdb7_pr.yml [branch:pgbouncer_1_8_1]
+
+Make a pull request to **"master"** or **"pgbouncer_1_8_1"** branch will trigger the corresponding pipeline to run.
+
+---
+
+The pipelines are run by the following command.
+
+`fly -t clients set-pipeline -p pgbouncer_gpdb6_and_gpdb7_pr -c bouncer_gpdb6_and_gpdb7_pr.yml -l ~/workspace/gp-continuous-integration/secrets/pgbouncer-secrets.client.yml -v git-access-token={{access-key-value}}`
+
+`fly -t clients set-pipeline -p pgbouncer_gpdb5_pr -c ./bouncer_gpdb5_pr.yml -l ~/workspace/gp-continuous-integration/secrets/pgbouncer-secrets.client.yml -v git-access-token={{access-key-value}}`
+
+The old pr pipeline *"bouncer_gpdb6_pr"* and *"bouncer_gpdb7_pr"* are deprecated. 

--- a/concourse/pipelines/bouncer_gpdb5_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb5_pr.yml
@@ -4,29 +4,31 @@
 
 resource_types:
   - name: pull_request
-    type: docker-image
+    type: registry-image
     source:
-      repository: jtarchie/pr
-
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
   - name: gcs
     type: docker-image
     source:
-        repository: frodenas/gcs-resource
+      repository: frodenas/gcs-resource
 
 resources:
 - name: pgbouncer_pr
   type: pull_request
   source:
     access_token: {{git-access-token}}
-    branch: pgbouncer_1_8_1
-    repo: greenplum-db/pgbouncer
-    uri: https://github.com/greenplum-db/pgbouncer.git
+    base_branch: "pgbouncer_1_8_1"
+    repository: greenplum-db/pgbouncer
+    ignore_paths:
+      - doc/*
+      - README*
 
 - name: centos-gpdb-dev-7
-  type: docker-image
+  type: registry-image
   source:
-    repository: pivotaldata/centos-gpdb-dev
-    tag: '7-gcc6.2-llvm3.7'
+    repository: gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test
+    tag: latest
 
 - name: gpdb5_src
   type: git
@@ -49,7 +51,7 @@ resources:
 jobs:
 - name: gpdb5_pgbouncer_test
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       version: every
@@ -83,12 +85,13 @@ jobs:
     timeout: 30m
   - task: psql_test
     input_mapping:
-      pgbouncer_src: pgbouncer_bin
+      pgbouncer_src: pgbouncer_pr
       gpdb_src: gpdb5_src
     config:
       platform: linux
       inputs:
       - name: pgbouncer_src
+      - name: pgbouncer_bin
       - name: gpdb_src
       - name: bin_gpdb
       run:
@@ -100,7 +103,7 @@ jobs:
 
 - name: set-pr-status
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       passed:

--- a/concourse/pipelines/bouncer_gpdb6_and_gpdb7_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb6_and_gpdb7_pr.yml
@@ -44,6 +44,7 @@ resources:
       bucket: {{gcs-bucket}}
       json_key: {{concourse-gcs-resources-service-account-key}}
       regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
+
   - name: gpdb7-centos7-build
     type: registry-image
     source:
@@ -71,6 +72,24 @@ resources:
       json_key: {{concourse-gcs-resources-service-account-key}}
       regexp: server/published/master/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
 
+  - name: gpdb7-ubuntu18.04-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb7-ubuntu18.04-build
+      tag: latest
+  
+  - name: gpdb7-ubuntu18.04-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb7-ubuntu18.04-test
+      tag: latest
+
+  - name: bin_gpdb7_ubuntu18.04
+    type: gcs
+    source:
+      bucket: {{gcs-bucket}}
+      json_key: {{concourse-gcs-resources-service-account-key}}
+      regexp: server/published/master/server-rc-(.*)-ubuntu18.04_x86_64.tar.gz
 jobs:
   - name: gpdb6_pgbouncer_test
     plan:
@@ -93,10 +112,10 @@ jobs:
         config:
           platform: linux
           inputs:
-            - name: pgbouncer_src
-            - name: gpdb_src
+          - name: pgbouncer_src
+          - name: gpdb_src
           outputs:
-            - name: bin_pgbouncer
+          - name: pgbouncer_compiled
           run:
             path: pgbouncer_src/concourse/scripts/build.bash
         image: gpdb6-centos7-test
@@ -108,7 +127,7 @@ jobs:
         timeout: 30m
       - task: psql_test
         input_mapping:
-          pgbouncer_src: pgbouncer_pr
+          pgbouncer_src: pgbouncer_compiled
           gpdb_src: gpdb6_src
         config:
           platform: linux
@@ -116,7 +135,6 @@ jobs:
             - name: pgbouncer_src
             - name: gpdb_src
             - name: bin_gpdb
-            - name: bin_pgbouncer
           run:
             path: pgbouncer_src/concourse/scripts/psql_test.bash
         image: gpdb6-centos7-test
@@ -144,10 +162,10 @@ jobs:
         config:
           platform: linux
           inputs:
-            - name: pgbouncer_src
-            - name: gpdb_src
+          - name: pgbouncer_src
+          - name: gpdb_src
           outputs:
-            - name: bin_pgbouncer
+          - name: pgbouncer_compiled
           run:
             path: pgbouncer_src/concourse/scripts/build.bash
         image: gpdb7-centos7-build
@@ -160,17 +178,66 @@ jobs:
       - task: psql_test
         input_mapping:
           gpdb_src: gpdb7_src
-          pgbouncer_src: pgbouncer_pr
+          pgbouncer_src: pgbouncer_compiled
         config:
           platform: linux
           inputs:
             - name: pgbouncer_src
             - name: gpdb_src
             - name: bin_gpdb
-            - name: bin_pgbouncer
           run:
             path: pgbouncer_src/concourse/scripts/psql_test.bash
         image: gpdb7-centos7-test
+        on_failure: *pr_failure
+        timeout: 30m
+  - name: test_pgbouncer_gpdb7-ubuntu18.04
+    plan:
+      - in_parallel:
+          - get: pgbouncer_pr
+            trigger: true
+            version: every
+          - get: gpdb7-ubuntu18.04-build
+          - get: gpdb7-ubuntu18.04-test
+          - get: gpdb7_src
+          - get: bin_gpdb
+            resource: bin_gpdb7_ubuntu18.04
+      - put: pgbouncer_pr
+        params:
+          path: pgbouncer_pr
+          status: pending
+      - task: build_pgbouncer
+        input_mapping:
+          pgbouncer_src: pgbouncer_pr
+          gpdb_src: gpdb7_src
+        config:
+          platform: linux
+          inputs:
+          - name: pgbouncer_src
+          - name: gpdb_src
+          outputs:
+          - name: pgbouncer_compiled
+          run:
+            path: pgbouncer_src/concourse/scripts/build.bash
+        image: gpdb7-ubuntu18.04-build
+        on_failure: &pr_failure
+          put: pgbouncer_pr
+          params:
+            path: pgbouncer_pr
+            status: failure
+        timeout: 30m
+      - task: psql_test
+        input_mapping:
+          gpdb_src: gpdb7_src
+          pgbouncer_src: pgbouncer_compiled
+        config:
+          platform: linux
+          inputs:
+            - name: pgbouncer_src
+            - name: gpdb_src
+            - name: bin_gpdb
+          run:
+            path: pgbouncer_src/concourse/scripts/psql_test.bash
+        image: gpdb7-ubuntu18.04-test
         on_failure: *pr_failure
         timeout: 30m
 
@@ -182,6 +249,7 @@ jobs:
             passed:
               - gpdb6_pgbouncer_test
               - test_pgbouncer_gpdb7-centos7
+              - test_pgbouncer_gpdb7-ubuntu18.04
       - put: report_pr_success
         resource: pgbouncer_pr
         params:

--- a/concourse/pipelines/bouncer_gpdb6_and_gpdb7_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb6_and_gpdb7_pr.yml
@@ -1,0 +1,189 @@
+## ======================================================================
+## resources
+## ======================================================================
+resource_types:
+  - name: pull_request
+    type: registry-image
+    source:
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
+  - name: gcs
+    type: docker-image
+    source:
+      repository: frodenas/gcs-resource
+
+resources:
+  - name: pgbouncer_pr
+    type: pull_request
+    source:
+      access_token: {{git-access-token}}
+      base_branch: "master"
+      repository: greenplum-db/pgbouncer
+      ignore_paths:
+        - doc/*
+        - README*
+
+  - name: gpdb6-centos7-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
+      tag: latest
+
+  - name: gpdb6_src
+    type: git
+    source:
+      branch: 6X_STABLE
+      uri: https://github.com/greenplum-db/gpdb.git
+      ignore_paths:
+        - gpdb-doc/*
+        - README*
+
+  - name: bin_gpdb6_centos7
+    type: gcs
+    source:
+      bucket: {{gcs-bucket}}
+      json_key: {{concourse-gcs-resources-service-account-key}}
+      regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
+  - name: gpdb7-centos7-build
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb7-centos7-build
+
+  - name: gpdb7-centos7-test
+    type: registry-image
+    source:
+      repository: gcr.io/data-gpdb-public-images/gpdb7-centos7-test
+      tag: latest
+
+  - name: gpdb7_src
+    type: git
+    source:
+      branch: master
+      uri: https://github.com/greenplum-db/gpdb.git
+      ignore_paths:
+        - gpdb-doc/*
+        - README*
+
+  - name: bin_gpdb7_centos7
+    type: gcs
+    source:
+      bucket: {{gcs-bucket}}
+      json_key: {{concourse-gcs-resources-service-account-key}}
+      regexp: server/published/master/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
+
+jobs:
+  - name: gpdb6_pgbouncer_test
+    plan:
+      - in_parallel:
+          - get: pgbouncer_pr
+            trigger: true
+            version: every
+          - get: gpdb6-centos7-test
+          - get: gpdb6_src
+          - get: bin_gpdb
+            resource: bin_gpdb6_centos7
+      - put: pgbouncer_pr
+        params:
+          path: pgbouncer_pr
+          status: pending
+      - task: build_pgbouncer
+        input_mapping:
+          pgbouncer_src: pgbouncer_pr
+          gpdb_src: gpdb6_src
+        config:
+          platform: linux
+          inputs:
+            - name: pgbouncer_src
+            - name: gpdb_src
+          outputs:
+            - name: bin_pgbouncer
+          run:
+            path: pgbouncer_src/concourse/scripts/build.bash
+        image: gpdb6-centos7-test
+        on_failure: &pr_failure
+          put: pgbouncer_pr
+          params:
+            path: pgbouncer_pr
+            status: failure
+        timeout: 30m
+      - task: psql_test
+        input_mapping:
+          pgbouncer_src: pgbouncer_pr
+          gpdb_src: gpdb6_src
+        config:
+          platform: linux
+          inputs:
+            - name: pgbouncer_src
+            - name: gpdb_src
+            - name: bin_gpdb
+            - name: bin_pgbouncer
+          run:
+            path: pgbouncer_src/concourse/scripts/psql_test.bash
+        image: gpdb6-centos7-test
+        on_failure: *pr_failure
+        timeout: 30m
+  - name: test_pgbouncer_gpdb7-centos7
+    plan:
+      - in_parallel:
+          - get: pgbouncer_pr
+            trigger: true
+            version: every
+          - get: gpdb7-centos7-build
+          - get: gpdb7-centos7-test
+          - get: gpdb7_src
+          - get: bin_gpdb
+            resource: bin_gpdb7_centos7
+      - put: pgbouncer_pr
+        params:
+          path: pgbouncer_pr
+          status: pending
+      - task: build_pgbouncer
+        input_mapping:
+          pgbouncer_src: pgbouncer_pr
+          gpdb_src: gpdb7_src
+        config:
+          platform: linux
+          inputs:
+            - name: pgbouncer_src
+            - name: gpdb_src
+          outputs:
+            - name: bin_pgbouncer
+          run:
+            path: pgbouncer_src/concourse/scripts/build.bash
+        image: gpdb7-centos7-build
+        on_failure: &pr_failure
+          put: pgbouncer_pr
+          params:
+            path: pgbouncer_pr
+            status: failure
+        timeout: 30m
+      - task: psql_test
+        input_mapping:
+          gpdb_src: gpdb7_src
+          pgbouncer_src: pgbouncer_pr
+        config:
+          platform: linux
+          inputs:
+            - name: pgbouncer_src
+            - name: gpdb_src
+            - name: bin_gpdb
+            - name: bin_pgbouncer
+          run:
+            path: pgbouncer_src/concourse/scripts/psql_test.bash
+        image: gpdb7-centos7-test
+        on_failure: *pr_failure
+        timeout: 30m
+
+  - name: set-pr-status
+    plan:
+      - in_parallel:
+          - get: pgbouncer_pr
+            trigger: true
+            passed:
+              - gpdb6_pgbouncer_test
+              - test_pgbouncer_gpdb7-centos7
+      - put: report_pr_success
+        resource: pgbouncer_pr
+        params:
+          path: pgbouncer_pr
+          status: success

--- a/concourse/pipelines/bouncer_gpdb6_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb6_pr.yml
@@ -1,13 +1,12 @@
 ## ======================================================================
 ## resources
 ## ======================================================================
-
 resource_types:
   - name: pull_request
-    type: docker-image
+    type: registry-image
     source:
-      repository: jtarchie/pr
-
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
   - name: gcs
     type: docker-image
     source:
@@ -18,14 +17,16 @@ resources:
   type: pull_request
   source:
     access_token: {{git-access-token}}
-    branch: master
-    repo: greenplum-db/pgbouncer
-    uri: https://github.com/greenplum-db/pgbouncer.git
+    base_branch: "master"
+    repository: greenplum-db/pgbouncer
+    ignore_paths:
+      - doc/*
+      - README*
 
 - name: gpdb6-centos7-test
-  type: docker-image
+  type: registry-image
   source:
-    repository: pivotaldata/gpdb6-centos7-test
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-test
     tag: latest
 
 - name: gpdb6_src
@@ -42,12 +43,12 @@ resources:
   source:
     bucket: {{gcs-bucket}}
     json_key: {{concourse-gcs-resources-service-account-key}}
-    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.tar.gz
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
 
 jobs:
 - name: gpdb6_pgbouncer_test
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       version: every
@@ -69,7 +70,7 @@ jobs:
       - name: pgbouncer_src
       - name: gpdb_src
       outputs:
-      - name: pgbouncer_bin
+      - name: bin_pgbouncer
       run:
         path: pgbouncer_src/concourse/scripts/build.bash
     image: gpdb6-centos7-test
@@ -81,7 +82,7 @@ jobs:
     timeout: 30m
   - task: psql_test
     input_mapping:
-      pgbouncer_src: pgbouncer_bin
+      pgbouncer_src: pgbouncer_pr
       gpdb_src: gpdb6_src
     config:
       platform: linux
@@ -89,6 +90,7 @@ jobs:
       - name: pgbouncer_src
       - name: gpdb_src
       - name: bin_gpdb
+      - name: bin_pgbouncer
       run:
         path: pgbouncer_src/concourse/scripts/psql_test.bash
     image: gpdb6-centos7-test
@@ -98,7 +100,7 @@ jobs:
 
 - name: set-pr-status
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       passed:

--- a/concourse/pipelines/bouncer_gpdb7_pr.yml
+++ b/concourse/pipelines/bouncer_gpdb7_pr.yml
@@ -4,10 +4,10 @@
 
 resource_types:
   - name: pull_request
-    type: docker-image
+    type: registry-image
     source:
-      repository: jtarchie/pr
-
+      repository: teliaoss/github-pr-resource
+      tag: v0.21.0
   - name: gcs
     type: docker-image
     source:
@@ -18,19 +18,21 @@ resources:
   type: pull_request
   source:
     access_token: {{git-access-token}}
-    branch: master
-    repo: greenplum-db/pgbouncer
-    uri: https://github.com/greenplum-db/pgbouncer.git
+    base_branch: "master"
+    repository: greenplum-db/pgbouncer
+    ignore_paths:
+      - doc/*
+      - README*
 
 - name: gpdb7-centos7-build
   type: registry-image
   source:
-    repository: pivotaldata/gpdb7-centos7-build
+    repository: gcr.io/data-gpdb-public-images/gpdb7-centos7-build
 
 - name: gpdb7-centos7-test
-  type: docker-image
+  type: registry-image
   source:
-    repository: pivotaldata/gpdb7-centos7-test
+    repository: gcr.io/data-gpdb-public-images/gpdb7-centos7-test
     tag: latest
 
 - name: gpdb7_src
@@ -47,12 +49,12 @@ resources:
   source:
     bucket: {{gcs-bucket}}
     json_key: {{concourse-gcs-resources-service-account-key}}
-    regexp: server/published/master/server-rc-(.*)-rhel7_x86_64.tar.gz
+    regexp: server/published/master/server-rc-(.*)-rhel7_x86_64.debug.tar.gz
 
 jobs:
 - name: test_pgbouncer_gpdb7-centos7
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       version: every
@@ -105,7 +107,7 @@ jobs:
 
 - name: set-pr-status
   plan:
-  - aggregate:
+  - in_parallel:
     - get: pgbouncer_pr
       trigger: true
       passed:

--- a/concourse/scripts/build.bash
+++ b/concourse/scripts/build.bash
@@ -15,12 +15,17 @@ function build_pgbouncer() {
     make install
     popd
 }
+function build_hba_test() {
+    pushd pgbouncer_src/test
+    make all
+    popd
+}
 
 
 function _main() {
     build_pgbouncer
-    pushd bin_pgbouncer
-    tar -czf bin_pgbouncer.tar.gz *
+    build_hba_test
+    cp -rf pgbouncer_src/* pgbouncer_compiled
 }
 
 _main "$@"

--- a/concourse/scripts/psql_test.bash
+++ b/concourse/scripts/psql_test.bash
@@ -33,14 +33,8 @@ function _main(){
     setup_gpdb_cluster
     chown -R gpadmin:gpadmin pgbouncer_src
     echo "gpadmin ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
-    pushd bin_pgbouncer
-    tar -zxf bin_pgbouncer.tar.gz
-    popd
-    cp bin_pgbouncer/bin/pgbouncer pgbouncer_src/
     cd pgbouncer_src/test
-    #su  gpadmin -c "make all"
-    su gpadmin -c "./test.sh"
-    su gpadmin -c "./ssl/test.sh"
+    su gpadmin -c "make check"
 }
 
 _main "$@"

--- a/include/bouncer.h
+++ b/include/bouncer.h
@@ -111,7 +111,6 @@ extern int cf_sbuf_len;
 #include "loader.h"
 #include "client.h"
 #include "server.h"
-#include "auth.h"
 #include "pooler.h"
 #include "proto.h"
 #include "objects.h"


### PR DESCRIPTION
The travis failed because the trusty platform is not stable any more, the upstream also disabled that platform.
The pr pipeline failed because of resources have upgraded.

This pr fixes travis and upgrades resources and merges old gpdb6 and gpdb7 pr pipeline to a new one. 