### PR TITLE
Enable scram-sha-256 testing for pgbouncer.

### DIFF
--- a/test/ssl/test.sh
+++ b/test/ssl/test.sh
@@ -61,6 +61,9 @@ if test $pg_majorversion -ge 10; then
 else
 	pg_supports_scram=false
 fi
+# Because gpdb6 has supported scram-sha-256, but the psql version is not changed,
+# so we enable scram test for it.
+pg_supports_scram=true
 
 stopit() {
 	local pid


### PR DESCRIPTION
After scram-sha-256 has been backported into 6X stable, both gpdb6
and gpdb7 will support scram authentication. This commit should be
merged after scram-sha-256 is supported by gpdb 6X_STABLE.