### PR TITLE
Remove the auth_file for LDAP users.

### DIFF
--- a/concourse/scripts/build.bash
+++ b/concourse/scripts/build.bash
@@ -11,7 +11,7 @@ function build_pgbouncer() {
     git submodule init
     git submodule update
     ./autogen.sh
-    ./configure --prefix=${HOME_DIR}/bin_pgbouncer/ --enable-evdns --with-pam --with-openssl
+    ./configure --prefix=${HOME_DIR}/bin_pgbouncer/ --enable-evdns --with-pam --with-openssl --with-ldap
     make install
     popd
 }

--- a/concourse/scripts/psql_test.bash
+++ b/concourse/scripts/psql_test.bash
@@ -9,7 +9,7 @@ source "${CWDIR}/common.bash"
 function setup_gpdb_cluster() {
     export TEST_OS=centos
     #export PGPORT=15432
-    export CONFIGURE_FLAGS=" --with-openssl"
+    export CONFIGURE_FLAGS=" --with-openssl --with-ldap"
     if [ ! -f "bin_gpdb/bin_gpdb.tar.gz" ];then
         mv bin_gpdb/*.tar.gz bin_gpdb/bin_gpdb.tar.gz
     fi
@@ -27,9 +27,21 @@ function setup_gpdb_cluster() {
     . /usr/local/greenplum-db-devel/greenplum_path.sh
     . gpdb_src/gpAux/gpdemo/gpdemo-env.sh
 }
+function install_openldap() {
+    local os=""
+    if [ -f /etc/redhat-release ];then
+          os="centos"
+    fi
+    if [ x$os == "xcentos" ];then
+        yum install -y openldap-servers openldap-clients
+    else
+        echo "Platform not support"
+    fi
+}
 
 function _main(){
     #yum install -y sudo
+    install_openldap
     setup_gpdb_cluster
     chown -R gpadmin:gpadmin pgbouncer_src
     echo "gpadmin ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,9 @@ elif test "$ac_cv_usual_glibc_gaia" = "yes"; then
 else
   echo "  adns    = compat"
 fi
+if test "$ldap_support" = "yes"; then
+        echo "Yes" > ldap_configured
+fi
 echo "  pam     = $pam_support"
 echo "  ldap    = $ldap_support"
 echo "  systemd = $with_systemd"

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,9 @@ elif test "$ac_cv_usual_glibc_gaia" = "yes"; then
 else
   echo "  adns    = compat"
 fi
+if test -f ldap_configured; then
+	rm -f ldap_configured
+fi
 if test "$ldap_support" = "yes"; then
         echo "Yes" > ldap_configured
 fi

--- a/doc/config.md
+++ b/doc/config.md
@@ -107,10 +107,15 @@ pam
 
 ldap
 :   LDAP is used to authenticate users with ldap server(OPENLDAP on linux or AD on windows).
-    In order to use ldap, `auth_type` needs to be set to `hba`. User's name needs to be
-    set in `auth_file` which name to be set under pgbouncer section. The value of
+    In order to use ldap, `auth_type` needs to be set to `hba`. The value of
     `auth_hba_file` has also to be set. And the content of the `auth_hba_file` could be
     the same format like `pg_hba.conf` in postgres.
+    AD server sends LDAP referrals and Linux chases those LDAP referrals by default.
+    On the one hand, chasing LDAP referrals may spend more time. 
+    On the other hand, it will hang if the referrals broken.
+    Disable chasing LDAP referrals can solve this issue:
+
+    echo "REFERRALS off" >> $HOME/.ldaprc
 
 hba
 :   The actual authentication type is loaded from `auth_hba_file`.  This allows different

--- a/include/objects.h
+++ b/include/objects.h
@@ -51,6 +51,7 @@ PgUser * add_db_user(PgDatabase *db, const char *name, const char *passwd) _MUST
 PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;
 
 PgUser * add_pam_user(const char *name, const char *passwd) _MUSTCHECK;
+PgUser * add_ldap_user(const char *name, const char *passwd) _MUSTCHECK;
 
 void accept_cancel_request(PgSocket *req);
 void forward_cancel_request(PgSocket *server);

--- a/src/admin.c
+++ b/src/admin.c
@@ -1518,15 +1518,13 @@ bool admin_pre_login(PgSocket *client, const char *username)
 	 * auth_type=any does not keep original username around,
 	 * so username based check has to take place here
 	 */
-	if (cf_auth_type == AUTH_ANY) {
-		if (strlist_contains(cf_admin_users, username)) {
-			client->login_user = admin_pool->db->forced_user;
-			client->admin_user = true;
-			return true;
-		} else if (strlist_contains(cf_stats_users, username)) {
-			client->login_user = admin_pool->db->forced_user;
-			return true;
-		}
+	if (strlist_contains(cf_admin_users, username)) {
+		client->login_user = admin_pool->db->forced_user;
+		client->admin_user = true;
+		return true;
+	} else if (strlist_contains(cf_stats_users, username)) {
+		client->login_user = admin_pool->db->forced_user;
+		return true;
 	}
 	return false;
 }

--- a/src/admin.c
+++ b/src/admin.c
@@ -1515,8 +1515,7 @@ bool admin_pre_login(PgSocket *client, const char *username)
 	}
 
 	/*
-	 * auth_type=any does not keep original username around,
-	 * so username based check has to take place here
+	 * remove the limitation of auth_type=any to enable admin user login to admin console
 	 */
 	if (strlist_contains(cf_admin_users, username)) {
 		client->login_user = admin_pool->db->forced_user;

--- a/src/auth_ldap.c
+++ b/src/auth_ldap.c
@@ -556,7 +556,7 @@ static void
 formatsearchfilter(char *filter, int length, const char *pattern, const char *user_name)
 {
 	int cur_len = 0;
-	while (*pattern != '\0')
+	while ((*pattern != '\0') && (cur_len < length))
 	{
 		if (strncmp(pattern, LPH_USERNAME, LPH_USERNAME_LEN) == 0)
 		{
@@ -564,8 +564,7 @@ formatsearchfilter(char *filter, int length, const char *pattern, const char *us
 			pattern += LPH_USERNAME_LEN;
 		}
 		else {
-			if(cur_len < length)
-				filter[cur_len++] = *pattern++;
+			filter[cur_len++] = *pattern++;
 		}
 	}
 	if (cur_len >= length)

--- a/src/auth_ldap.c
+++ b/src/auth_ldap.c
@@ -521,24 +521,24 @@ InitializeLDAPConnection(struct ldap_auth_request *request, LDAP **ldap)
 	}
 
 	if ((r = ldap_set_option(*ldap, LDAP_OPT_PROTOCOL_VERSION, &ldapversion)) != LDAP_SUCCESS) {
-		ldap_unbind(*ldap);
 		log_warning("could not set LDAP protocol version: %s", ldap_err2string(r));
+		ldap_unbind(*ldap);
 		return false;
 	}
 
-	ts.tv_sec = 10;
+	ts.tv_sec = 3;
 	ts.tv_usec = 0;
 	if ((r = ldap_set_option(*ldap, LDAP_OPT_NETWORK_TIMEOUT, &ts)) != LDAP_SUCCESS) {
-		ldap_unbind(*ldap);
 		log_warning("could not set LDAP timeout: %s", ldap_err2string(r));
+		ldap_unbind(*ldap);
 		return false;
 	}
 
 	if (request->ldaptls) {
 		if ((r = ldap_start_tls_s(*ldap, NULL, NULL)) != LDAP_SUCCESS) {
-			ldap_unbind(*ldap);
 			log_warning("could not start LDAP TLS session: %s, server: %s, port: %d",
 						ldap_err2string(r), request->ldapserver, request->ldapport);
+			ldap_unbind(*ldap);
 			return false;
 		}
 	}

--- a/src/auth_ldap.c
+++ b/src/auth_ldap.c
@@ -73,9 +73,11 @@ struct ldap_auth_request {
 	int param_pos;
 	/* ldap specific parameters */
 	bool ldaptls;
+	char *ldapscheme;
 	char *ldapserver;
 	char *ldapbinddn;
 	char *ldapsearchattribute;
+	char *ldapsearchfilter;
 	char *ldapbasedn;
 	char *ldapbindpasswd;
 	char *ldapprefix;
@@ -190,9 +192,10 @@ static bool is_valid_parameter(struct ldap_auth_request *request)
 		if (request->ldapbasedn ||
 			request->ldapbinddn ||
 			request->ldapbindpasswd ||
-			request->ldapsearchattribute) {
+			request->ldapsearchattribute ||
+			request->ldapsearchfilter ) {
 			log_warning("cannot use ldapbasedn, ldapbinddn, ldapbindpasswd, "
-						"ldapsearchattribute, or ldapurl together with ldapprefix");
+						"ldapsearchattribute, ldapsearchfilter, or ldapurl together with ldapprefix");
 			return false;
 		}
 	} else if (!request->ldapbasedn) {
@@ -200,11 +203,17 @@ static bool is_valid_parameter(struct ldap_auth_request *request)
 				"authentication method \"ldap\" requires argument \"ldapbasedn\", \"ldapprefix\", or \"ldapsuffix\" to be set");
 		return false;
 	}
-
-	if ((request->ldaptls || request->ldapport != 0) && strncmp(request->ldapserver, "ldaps://", 8) == 0) {
-		log_warning("cannot use 'ldaptls' or 'ldapport' with 'ldapserver' start with 'ldaps://'");
+	/*
+	 * When using search+bind, you can either use a simple attribute
+	 * (defaulting to "uid") or a fully custom search filter.  You can't
+	 * do both.
+	 */
+	if (request->ldapsearchattribute && request->ldapsearchfilter)
+	{
+		log_warning("cannot use ldapsearchattribute together with ldapsearchfilter");
 		return false;
 	}
+
 	return true;
 }
 
@@ -217,11 +226,14 @@ static bool parse_ldapurl(struct ldap_auth_request *request, char *val)
 		return false;
 	}
 
-	if (strcmp(urldata->lud_scheme, "ldap") != 0) {
+	if (strcmp(urldata->lud_scheme, "ldap") != 0 &&
+		strcmp(urldata->lud_scheme, "ldaps") != 0) {
 		log_warning("unsupported LDAP URL scheme: %s", urldata->lud_scheme);
 		ldap_free_urldesc(urldata);
 		return false;
 	}
+	if (urldata->lud_scheme)
+		ldap_parameter_dup(request, ldapscheme, urldata->lud_scheme);
 
 	if (urldata->lud_host)
 		ldap_parameter_dup(request, ldapserver, urldata->lud_host);
@@ -231,11 +243,8 @@ static bool parse_ldapurl(struct ldap_auth_request *request, char *val)
 	if (urldata->lud_attrs)
 		ldap_parameter_dup(request, ldapsearchattribute, urldata->lud_attrs[0]); /* only use first one */
 	request->ldapscope = urldata->lud_scope;
-	if (urldata->lud_filter) {
-		log_warning("filters not supported in LDAP URLs");
-		ldap_free_urldesc(urldata);
-		return false;
-	}
+	if (urldata->lud_filter)
+		ldap_parameter_dup(request, ldapsearchfilter, urldata->lud_filter);
 	ldap_free_urldesc(urldata);
 	return true;
 }
@@ -284,6 +293,12 @@ static bool ldap_initialize_parameters(struct ldap_auth_request *request, char *
 				request->ldaptls = true;
 			else
 				request->ldaptls = false;
+		} else if (strcmp(key, "ldapscheme") == 0) {
+			if (strcmp(value, "ldap") != 0 && strcmp(value, "ldaps") != 0) {
+				log_warning("invalid ldapscheme value: \"%s\"", value);
+				return false;
+			}
+			ldap_parameter_dup(request, ldapscheme, value);
 		} else if (strcmp(key, "ldapport") == 0) {
 			request->ldapport = atoi(value);
 			if (request->ldapport == 0) {
@@ -296,6 +311,8 @@ static bool ldap_initialize_parameters(struct ldap_auth_request *request, char *
 			ldap_parameter_dup(request, ldapbinddn, value);
 		} else if (strcmp(key, "ldapsearchattribute") == 0) {
 			ldap_parameter_dup(request, ldapsearchattribute, value);
+		} else if (strcmp(key, "ldapsearchfilter") == 0) {
+			ldap_parameter_dup(request, ldapsearchfilter, value);
 		} else if (strcmp(key, "ldapbasedn") == 0) {
 			ldap_parameter_dup(request, ldapbasedn, value);
 		} else if (strcmp(key, "ldapbindpasswd") == 0) {
@@ -528,7 +545,33 @@ InitializeLDAPConnection(struct ldap_auth_request *request, LDAP **ldap)
 
 	return true;
 }
-
+/* Placeholders recognized by formatsearchfilter.  For now just one. */
+#define LPH_USERNAME "$username"
+#define LPH_USERNAME_LEN strlen(LPH_USERNAME)
+/*
+ * Return a newly allocated C string copied from "pattern" with all
+ * occurrences of the placeholder "$username" replaced with "user_name".
+ */
+static void
+formatsearchfilter(char *filter, int length, const char *pattern, const char *user_name)
+{
+	int cur_len = 0;
+	while (*pattern != '\0')
+	{
+		if (strncmp(pattern, LPH_USERNAME, LPH_USERNAME_LEN) == 0)
+		{
+			cur_len += snprintf(filter + cur_len, length - cur_len, "%s", user_name);
+			pattern += LPH_USERNAME_LEN;
+		}
+		else {
+			if(cur_len < length)
+				filter[cur_len++] = *pattern++;
+		}
+	}
+	if (cur_len >= length)
+		cur_len = length - 1;
+	filter[cur_len] = '\0';
+}
 /*
  * Perform LDAP authentication
  */
@@ -542,13 +585,20 @@ checkldapauth(struct ldap_auth_request *request)
 	if (!ldap_initialize_parameters(request, request->client->ldap_parameters)) {
 		return false;
 	}
-	if (!request->ldapserver || request->ldapserver[0] == '\0') {
-		log_warning("LDAP server not specified");
+	if ((!request->ldapserver || request->ldapserver[0] == '\0') &&
+		(!request->ldapbasedn || request->ldapbasedn[0] == '\0')) {
+		log_warning("LDAP server not specified, and no ldapbasedn");
 		return false;
 	}
 
 	if (request->ldapport == 0)
-		request->ldapport = LDAP_PORT;
+	{
+		if (request->ldapscheme != NULL &&
+			strcmp(request->ldapscheme, "ldaps") == 0)
+			request->ldapport = LDAPS_PORT;
+		else
+			request->ldapport = LDAP_PORT;
+	}
 
 	if (request->password[0] == '\0') {
 		return false;
@@ -599,16 +649,20 @@ checkldapauth(struct ldap_auth_request *request)
 			log_warning("could not perform initial LDAP bind for ldapbinddn \"%s\" on server \"%s\": %s",
 						request->ldapbinddn ? request->ldapbinddn : "",
 						request->ldapserver, ldap_err2string(r));
+			ldap_unbind(ldap);
 			return false;
 		}
 
 		/* Fetch just one attribute, else *all* attributes are returned */
-		attributes[0] = request->ldapsearchattribute ? request->ldapsearchattribute : "uid";
-		attributes[1] = NULL;
-
-		snprintf(filter, LDAP_LONG_LENGTH, "(%s=%s)",
-				 attributes[0],
-				 request->username);
+		if (request->ldapsearchfilter)
+			formatsearchfilter(filter, LDAP_LONG_LENGTH, request->ldapsearchfilter, request->username);
+		else {
+			attributes[0] = request->ldapsearchattribute ? request->ldapsearchattribute : "uid";
+			attributes[1] = NULL;
+			snprintf(filter, LDAP_LONG_LENGTH, "(%s=%s)",
+					 attributes[0],
+					 request->username);
+		}
 
 		r = ldap_search_s(ldap,
 						  request->ldapbasedn,
@@ -621,6 +675,7 @@ checkldapauth(struct ldap_auth_request *request)
 		if (r != LDAP_SUCCESS) {
 			log_warning("could not search LDAP for filter \"%s\" on server \"%s\": %s",
 						filter, request->ldapserver, ldap_err2string(r));
+			ldap_unbind(ldap);
 			return false;
 		}
 
@@ -635,6 +690,7 @@ checkldapauth(struct ldap_auth_request *request)
 				log_warning("LDAP search for filter \"%s\" on server \"%s\" returned %d entries.",
 							filter, request->ldapserver, count);
 			}
+			ldap_unbind(ldap);
 			ldap_msgfree(search_message);
 			return false;
 		}
@@ -647,6 +703,7 @@ checkldapauth(struct ldap_auth_request *request)
 			(void) ldap_get_option(ldap, LDAP_OPT_ERROR_NUMBER, &error);
 			log_warning("could not get dn for the first entry matching \"%s\" on server \"%s\": %s",
 						filter, request->ldapserver, ldap_err2string(error));
+			ldap_unbind(ldap);
 			ldap_msgfree(search_message);
 			return false;
 		}

--- a/src/auth_ldap.c
+++ b/src/auth_ldap.c
@@ -610,7 +610,7 @@ checkldapauth(struct ldap_auth_request *request)
 		char filter[LDAP_LONG_LENGTH];
 		LDAPMessage *search_message;
 		LDAPMessage *entry;
-		char *attributes[2];
+		char *attributes[2] = {LDAP_NO_ATTRS, NULL};
 		char *dn;
 		char *c;
 		int count;

--- a/src/auth_ldap.c
+++ b/src/auth_ldap.c
@@ -208,8 +208,7 @@ static bool is_valid_parameter(struct ldap_auth_request *request)
 	 * (defaulting to "uid") or a fully custom search filter.  You can't
 	 * do both.
 	 */
-	if (request->ldapsearchattribute && request->ldapsearchfilter)
-	{
+	if (request->ldapsearchattribute && request->ldapsearchfilter) {
 		log_warning("cannot use ldapsearchattribute together with ldapsearchfilter");
 		return false;
 	}
@@ -556,14 +555,11 @@ static void
 formatsearchfilter(char *filter, int length, const char *pattern, const char *user_name)
 {
 	int cur_len = 0;
-	while ((*pattern != '\0') && (cur_len < length))
-	{
-		if (strncmp(pattern, LPH_USERNAME, LPH_USERNAME_LEN) == 0)
-		{
+	while ((*pattern != '\0') && (cur_len < length)) {
+		if (strncmp(pattern, LPH_USERNAME, LPH_USERNAME_LEN) == 0) {
 			cur_len += snprintf(filter + cur_len, length - cur_len, "%s", user_name);
 			pattern += LPH_USERNAME_LEN;
-		}
-		else {
+		} else {
 			filter[cur_len++] = *pattern++;
 		}
 	}
@@ -590,8 +586,7 @@ checkldapauth(struct ldap_auth_request *request)
 		return false;
 	}
 
-	if (request->ldapport == 0)
-	{
+	if (request->ldapport == 0) {
 		if (request->ldapscheme != NULL &&
 			strcmp(request->ldapscheme, "ldaps") == 0)
 			request->ldapport = LDAPS_PORT;

--- a/src/client.c
+++ b/src/client.c
@@ -360,6 +360,21 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 			disconnect_client(client, true, "bouncer resources exhaustion");
 			return false;
 		}
+	} else if (cf_auth_type == AUTH_HBA &&
+		hba_eval(parsed_hba, &client->remote_addr, !!client->sbuf.tls,
+			 dbname, username, NULL) == AUTH_LDAP) {
+		if (client->db->auth_user) {
+			slog_error(client, "LDAP can't be used together with database authentication");
+			disconnect_client(client, true, "bouncer config error");
+			return false;
+		}
+		/* Password will be set after successful authentication when not in takeover mode */
+		client->login_user = add_ldap_user(username, password);
+		if (!client->login_user) {
+			slog_error(client, "set_pool(): failed to allocate new LDAP user");
+			disconnect_client(client, true, "bouncer resources exhaustion");
+			return false;
+		}
 	} else {
 		client->login_user = find_user(username);
 		if (!client->login_user) {

--- a/src/objects.c
+++ b/src/objects.c
@@ -435,7 +435,7 @@ PgUser *add_pam_user(const char *name, const char *passwd)
 		safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
 	return user;
 }
-/* Add PAM user. The logic is same as in add_db_user */
+/* Add LDAP user. The logic is same as in add_db_user */
 PgUser *add_ldap_user(const char *name, const char *passwd)
 {
 	PgUser *user = NULL;

--- a/src/objects.c
+++ b/src/objects.c
@@ -34,10 +34,11 @@ struct AATree user_tree;
 /*
  * All PAM users are kept here. We need to differentiate two user
  * lists to avoid user clashing for different authentication types,
- * and because pam_user_tree is closer to PgDatabase.user_tree in
+ * and because pam_user_tree/ldap_user_tree is closer to PgDatabase.user_tree in
  * logic.
  */
 struct AATree pam_user_tree;
+struct AATree ldap_user_tree;
 
 /*
  * client and server objects will be pre-allocated
@@ -116,6 +117,7 @@ void init_objects(void)
 {
 	aatree_init(&user_tree, user_node_cmp, NULL);
 	aatree_init(&pam_user_tree, user_node_cmp, NULL);
+	aatree_init(&ldap_user_tree, user_node_cmp, NULL);
 	user_cache = slab_create("user_cache", sizeof(PgUser), 0, NULL, USUAL_ALLOC);
 	db_cache = slab_create("db_cache", sizeof(PgDatabase), 0, NULL, USUAL_ALLOC);
 	pool_cache = slab_create("pool_cache", sizeof(PgPool), 0, NULL, USUAL_ALLOC);
@@ -427,6 +429,31 @@ PgUser *add_pam_user(const char *name, const char *passwd)
 		safe_strcpy(user->name, name, sizeof(user->name));
 
 		aatree_insert(&pam_user_tree, (uintptr_t)user->name, &user->tree_node);
+		user->pool_mode = POOL_INHERIT;
+	}
+	if (passwd)
+		safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
+	return user;
+}
+/* Add PAM user. The logic is same as in add_db_user */
+PgUser *add_ldap_user(const char *name, const char *passwd)
+{
+	PgUser *user = NULL;
+	struct AANode *node;
+
+	node = aatree_search(&ldap_user_tree, (uintptr_t)name);
+	user = node ? container_of(node, PgUser, tree_node) : NULL;
+
+	if (user == NULL) {
+		user = slab_alloc(user_cache);
+		if (!user)
+			return NULL;
+
+		list_init(&user->head);
+		list_init(&user->pool_list);
+		safe_strcpy(user->name, name, sizeof(user->name));
+
+		aatree_insert(&ldap_user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
 	}
 	if (passwd)

--- a/test/ldap/ldap.ldif
+++ b/test/ldap/ldap.ldif
@@ -1,0 +1,20 @@
+dn: dc=example,dc=net
+objectClass: top
+objectClass: dcObject
+objectClass: organization
+dc: example
+o: ExampleCo
+
+dn: uid=ldapuser1,dc=example,dc=net
+objectClass: inetOrgPerson
+objectClass: posixAccount
+uid: ldapuser1
+sn: Lastname
+givenName: Firstname
+cn: First Test User
+displayName: First Test User
+uidNumber: 101
+gidNumber: 100
+homeDirectory: /home/ldapuser1
+mail: ldapuser1@example.net
+

--- a/test/test.ini
+++ b/test/test.ini
@@ -40,6 +40,7 @@ unix_socket_dir = /tmp
 
 auth_type = trust
 auth_file = userlist.txt
+auth_hba_file = hba.conf
 
 pool_mode = statement
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -201,6 +201,7 @@ psql -X -p $PG_PORT -d p0 -c "select * from pg_user" | grep pswcheck > /dev/null
 	psql -X -o /dev/null -p $PG_PORT -c "create user someuser with password 'anypasswd';" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user maxedout;" p0 || exit 1
 	psql -X -o /dev/null -p $PG_PORT -c "create user longpass with password '$long_password';" p0 || exit 1
+	psql -X -o /dev/null -p $PG_PORT -c "create user ldapuser1" p0 || exit 1
 	if $pg_supports_scram; then
 		psql -X -o /dev/null -p $PG_PORT -c "set password_encryption = 'md5'; create user muser1 password 'foo';" p0 || exit 1
 		psql -X -o /dev/null -p $PG_PORT -c "set password_encryption = 'md5'; create user muser2 password 'wrong';" p0 || exit 1
@@ -1328,6 +1329,92 @@ test_cancel_pool_size() {
 
 	return 0
 }
+# Test ldap authentication
+test_ldap_authentication() {
+	osname=$(uname -s)
+	if [ $osname != "Linux" ];then 
+		return 77
+	fi
+	slapd=/usr/sbin/slapd
+	if [ -d '/etc/ldap/schema' ]
+	then
+		ldap_schema_dir='/etc/ldap/schema'
+	else
+		ldap_schema_dir='/etc/openldap/schema'
+	fi
+	if [ ! -e $slapd ];then
+		return 77
+	fi
+
+	ldap_pwd=$(pwd)/ldap
+
+	ldap_datadir="${ldap_pwd}/openldap-data"
+	slapd_conf="${ldap_pwd}/slapd.conf"
+	slapd_pidfile="${ldap_pwd}/slapd.pid"
+	slapd_logfile="${ldap_pwd}/slapd.log"
+	ldap_conf="${ldap_pwd}/ldap.conf"
+	ldap_server='localhost'
+	ldap_port=49152
+	ldap_url="ldap://$ldap_server:$ldap_port"
+	ldap_basedn='dc=example,dc=net'
+	ldap_rootdn='cn=Manager,dc=example,dc=net'
+	ldap_rootpw='secret'
+
+cat >$slapd_conf <<-EOF
+include $ldap_schema_dir/core.schema
+include $ldap_schema_dir/cosine.schema
+include $ldap_schema_dir/nis.schema
+include $ldap_schema_dir/inetorgperson.schema
+pidfile $slapd_pidfile
+logfile $slapd_logfile
+access to *
+        by * read
+        by anonymous auth
+
+database ldif
+directory $ldap_datadir
+suffix "dc=example,dc=net"
+rootdn "$ldap_rootdn"
+rootpw $ldap_rootpw
+EOF
+
+cat >$ldap_conf <<-EOF
+TLS_REQCERT never
+EOF
+
+	if [ -d $ldap_datadir ];then
+		rm -rf $ldap_datadir
+	fi
+	mkdir -p $ldap_datadir
+
+	echo $slapd "-f" $slapd_conf "-h" $ldap_url
+	$slapd -f $slapd_conf -h $ldap_url && sleep 1
+
+	export LDAPURI=$ldap_url
+	export LDAPBINDDN=$ldap_rootdn
+	export LDAPCONF=$ldap_conf
+
+	echo ldapadd -x -w $ldap_rootpw -f $ldap_pwd/ldap.ldif -H $ldap_url
+	ldapadd -x -w $ldap_rootpw -f $ldap_pwd/ldap.ldif
+	ldappasswd -x -w $ldap_rootpw -s secret1 'uid=ldapuser1,dc=example,dc=net'
+	ldapsearch -x -b "dc=example,dc=net"
+
+	local re=0
+	#1 test
+cat >hba.conf<<EOF
+host all ldapuser1 0.0.0.0/0 ldap ldapserver=$ldap_server ldapport=$ldap_port ldapprefix="uid=" ldapsuffix=",dc=example,dc=net"
+EOF
+
+	echo 'auth_type = hba' >> test.ini
+	admin "reload" && sleep 1
+	PGPASSWORD=secret1 psql -X -d p0 -U ldapuser1 -c "select 1"
+	if [ $? -ne 0 ] ;then
+		re=1
+	fi
+
+	kill -2 $(cat $slapd_pidfile)
+	return $re
+}
 
 testlist="
 test_show_version
@@ -1379,6 +1466,7 @@ test_auto_database
 test_cancel
 test_cancel_wait
 test_cancel_pool_size
+test_ldap_authentication
 "
 
 if [ $# -gt 0 ]; then

--- a/test/test.sh
+++ b/test/test.sh
@@ -1331,6 +1331,9 @@ test_cancel_pool_size() {
 }
 # Test ldap authentication
 test_ldap_authentication() {
+	if [ ! -e ../ldap_configured ];then
+		return 77	
+	fi
 	osname=$(uname -s)
 	if [ $osname != "Linux" ];then 
 		return 77


### PR DESCRIPTION
    Seperate the userlist of LDAP users from password user list so that
    we do not need to add username in user.txt file for LDAP users. This
    will benefit from the pg-ldap-sync project which provide a way to
    sync user role of LDAP automatically.
    When all LDAP users use the same hba rule, no changes will be made
    if we use pg-ldap-sync, user roles will be created or dropped
    according to the LDAP server when customer uses pgbouncer through
    LDAP authentication.

    After this commits, there will be only two configs that should be
    changed if users wants to login through LDAP authentication:
    1. auth_hba_file
        Example:
        `cat hba.conf`
        `host all user1 0.0.0.0/0 ldap ldapserver=10.117.190.215 ldapbasedn="CN=Users,DC=greenplum,DC=org" ldapbinddn="CN=Administrator,CN=Users,DC=greenplum,DC=org" ldapbindpasswd="Welcome1!" ldapsearchattribute="sAMAccountname"`

    2. auth_type
        `auth_type = hba`