### PR TITLE
Revert the changes of admin login in the last commit.

### DIFF
--- a/src/admin.c
+++ b/src/admin.c
@@ -1515,15 +1515,18 @@ bool admin_pre_login(PgSocket *client, const char *username)
 	}
 
 	/*
-	 * remove the limitation of auth_type=any to enable admin user login to admin console
+	 * auth_type=any does not keep original username around,
+	 * so username based check has to take place here
 	 */
-	if (strlist_contains(cf_admin_users, username)) {
-		client->login_user = admin_pool->db->forced_user;
-		client->admin_user = true;
-		return true;
-	} else if (strlist_contains(cf_stats_users, username)) {
-		client->login_user = admin_pool->db->forced_user;
-		return true;
+	if (cf_auth_type == AUTH_ANY) {
+		if (strlist_contains(cf_admin_users, username)) {
+			client->login_user = admin_pool->db->forced_user;
+			client->admin_user = true;
+			return true;
+		} else if (strlist_contains(cf_stats_users, username)) {
+			client->login_user = admin_pool->db->forced_user;
+			return true;
+		}
 	}
 	return false;
 }

--- a/test/test.ini
+++ b/test/test.ini
@@ -41,6 +41,7 @@ unix_socket_dir = /tmp
 auth_type = trust
 auth_file = userlist.txt
 auth_hba_file = hba.conf
+admin_users = admin_user
 
 pool_mode = statement
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -1329,6 +1329,28 @@ test_cancel_pool_size() {
 
 	return 0
 }
+# Test admin user login in different auth_type
+test_admin_user_login() {
+	# auth_type = hba
+	cat >hba.conf<<EOF
+host pgbouncer admin_user 0.0.0.0/0 trust
+EOF
+	echo 'auth_type = hba' >> test.ini
+	admin "reload" && sleep 1
+	psql -X -d pgbouncer -U admin_user -c "show pools"
+	if [ $? -ne 0 ] ;then
+		re=1
+	fi
+
+	# auth_type = md5
+	echo 'auth_type = md5' >> test.ini
+	admin "reload" && sleep 1
+	PGPASSWORD=a psql -X -d pgbouncer -U admin_user -c "show pools"
+	if [ $? -ne 0 ] ;then
+		re=1
+	fi
+	return $re
+}
 # Test ldap authentication
 test_ldap_authentication() {
 	if [ ! -e ../ldap_configured ];then
@@ -1519,6 +1541,7 @@ test_auto_database
 test_cancel
 test_cancel_wait
 test_cancel_pool_size
+test_admin_user_login
 test_ldap_authentication
 "
 

--- a/test/userlist.txt
+++ b/test/userlist.txt
@@ -17,3 +17,4 @@
 "scramuser2" "SCRAM-SHA-256$4096:BUYIT9YAsWf036OHLPfv2Q==$zuk7pzdEc5tvftsRIuwlStNxVc+wIE/xfDs7ahsKN0k=:Lov6mndE0DmlgtY60e1LyDsLctQyoH+Bvkm9K9njSa8="
 
 "scramuser3" "baz"
+"admin_user" "a"


### PR DESCRIPTION
The previous commit d83d349fba7f3de9edb5dca5f3e703796a32fe04 may cause a regression that when admin users login into pgbouncer database, the login user will be switched to pgbouncer which is not a good way for "hba" or other auth_type to login into pgbouncer database.
If you want to login into pgbouncer database as admin_user when auth_type is set to "hba", you need to add an entry for the admin user in auth_hba_file and auth_file. Also if you set the login rule as md5 or other authentication ways which need password, you need to set the password in auth_file.

Here is an example:

pgbouncer configuration:
```
listen_addr = 0.0.0.0
listen_port = 6432
unix_socket_dir = /tmp
auth_type = hba
auth_hba_file = hba.conf
auth_file = user.txt
admin_users = gpadmin
stats_users = test
```
cat hba.conf
```
host pgbouncer gpadmin 0.0.0.0/0 md5
host pgbouncer test 0.0.0.0/0 trust
```
cat user.txt
```
"gpadmin" "a"
"test" ""
```

login as gpadmin:
```
psql  -U gpadmin pgbouncer -p 6432 -h 127.0.0.1
Password for user gpadmin:
psql (9.4.26, server 1.16.1/bouncer)
Type "help" for help.

pgbouncer=#
```
login as test:
```
psql -d  pgbouncer -p 6432 -h 127.0.0.1 -U test
psql (9.4.26, server 1.16.1/bouncer)
Type "help" for help.

pgbouncer=#
```