### PR TITLE
Keep md5 and ldap user in the same tree.

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -51,7 +51,6 @@ PgUser * add_db_user(PgDatabase *db, const char *name, const char *passwd) _MUST
 PgUser * force_user(PgDatabase *db, const char *username, const char *passwd) _MUSTCHECK;
 
 PgUser * add_pam_user(const char *name, const char *passwd) _MUSTCHECK;
-PgUser * add_ldap_user(const char *name, const char *passwd) _MUSTCHECK;
 
 void accept_cancel_request(PgSocket *req);
 void forward_cancel_request(PgSocket *server);

--- a/src/client.c
+++ b/src/client.c
@@ -369,7 +369,7 @@ bool set_pool(PgSocket *client, const char *dbname, const char *username, const 
 			return false;
 		}
 		/* Password will be set after successful authentication when not in takeover mode */
-		client->login_user = add_ldap_user(username, password);
+		client->login_user = add_user(username, password);
 		if (!client->login_user) {
 			slog_error(client, "set_pool(): failed to allocate new LDAP user");
 			disconnect_client(client, true, "bouncer resources exhaustion");

--- a/src/objects.c
+++ b/src/objects.c
@@ -34,11 +34,10 @@ struct AATree user_tree;
 /*
  * All PAM users are kept here. We need to differentiate two user
  * lists to avoid user clashing for different authentication types,
- * and because pam_user_tree/ldap_user_tree is closer to PgDatabase.user_tree in
+ * and because pam_user_tree is closer to PgDatabase.user_tree in
  * logic.
  */
 struct AATree pam_user_tree;
-struct AATree ldap_user_tree;
 
 /*
  * client and server objects will be pre-allocated
@@ -117,7 +116,6 @@ void init_objects(void)
 {
 	aatree_init(&user_tree, user_node_cmp, NULL);
 	aatree_init(&pam_user_tree, user_node_cmp, NULL);
-	aatree_init(&ldap_user_tree, user_node_cmp, NULL);
 	user_cache = slab_create("user_cache", sizeof(PgUser), 0, NULL, USUAL_ALLOC);
 	db_cache = slab_create("db_cache", sizeof(PgDatabase), 0, NULL, USUAL_ALLOC);
 	pool_cache = slab_create("pool_cache", sizeof(PgPool), 0, NULL, USUAL_ALLOC);
@@ -381,7 +379,8 @@ PgUser *add_user(const char *name, const char *passwd)
 		aatree_insert(&user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
 	}
-	safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
+	if (passwd != NULL)
+		safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
 	return user;
 }
 
@@ -429,31 +428,6 @@ PgUser *add_pam_user(const char *name, const char *passwd)
 		safe_strcpy(user->name, name, sizeof(user->name));
 
 		aatree_insert(&pam_user_tree, (uintptr_t)user->name, &user->tree_node);
-		user->pool_mode = POOL_INHERIT;
-	}
-	if (passwd)
-		safe_strcpy(user->passwd, passwd, sizeof(user->passwd));
-	return user;
-}
-/* Add LDAP user. The logic is same as in add_db_user */
-PgUser *add_ldap_user(const char *name, const char *passwd)
-{
-	PgUser *user = NULL;
-	struct AANode *node;
-
-	node = aatree_search(&ldap_user_tree, (uintptr_t)name);
-	user = node ? container_of(node, PgUser, tree_node) : NULL;
-
-	if (user == NULL) {
-		user = slab_alloc(user_cache);
-		if (!user)
-			return NULL;
-
-		list_init(&user->head);
-		list_init(&user->pool_list);
-		safe_strcpy(user->name, name, sizeof(user->name));
-
-		aatree_insert(&ldap_user_tree, (uintptr_t)user->name, &user->tree_node);
 		user->pool_mode = POOL_INHERIT;
 	}
 	if (passwd)


### PR DESCRIPTION
Some customers have the need to switch authentication method
by changing the `auth_hba_file` and reload without restarting pgbouncer.
However the ldap implementation adds new users in a different user tree.
So when the customer switches the authentication method, it tries
to search a created pool on the new user->pools list. As the new user
and the old user have the same username, but do not point to the same
structure, so it will try to add a new pool to pool_list which
will trigger a fatal error because a pool with the same 'username' and
'dbname' has already been added in pool_list.

This commit will remove the difference between md5 and ldap user so
that the old and new user could share the same data structure. So there is
no need to add a new pool to pool_list when customer switch the
authentication method because the 'username' and 'dbname' have not changed.

The common steps is as follows:
1. login with ldap authentication method
2. modify hba.conf file to md5 method and reload
3. touch userlist.txt(need to refresh user password which is important if last authentication method is ldap, so the password stored will be the ldap password, this step will refresh the password with the md5 password)
4. relogin using the new authentication method like md5.